### PR TITLE
Add support for specifying custom colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,47 @@ A library for colorizing JSON strings
 
 This package is a simple console syntax highlighter for JSON.
 
-# Installation
+## Installation
 `npm install --save json-colorizer`
 
-# Usage
-    var colorize = require('json-colorizer');
-    console.log(colorize( { "foo": "bar" });
+## Usage
 
+```js
+var colorize = require('json-colorizer');
+console.log(colorize({ "foo": "bar" });
+```
+
+If you pass a string to the colorize function, it will treat it as pre-serialized JSON. This can be used in order to colorize pretty-printed JSON:
+
+```js
+var colorize = require('json-colorizer');
+var json = JSON.stringify({"foo": "bar"}, null, 2)
+console.log(colorize(json);
+```
+
+
+## Specifying colors
+
+You can specify a function to use for coloring individual tokens by providing a `colors` object:
+
+```js
+var colorize = require('json-colorizer');
+var chalk = require('chalk')
+console.log(colorize({ "foo": "bar" }, {
+  colors: {
+    STRING_KEY: chalk.green
+  }
+});
+```
+
+The tokens available are:
+
+* `BRACE`
+* `BRACKET`
+* `COLON`
+* `COMMA`
+* `STRING_KEY`
+* `STRING_LITERAL`
+* `NUMBER_LITERAL`
+* `BOOLEAN_LITERAL`
+* `NULL_LITERAL`

--- a/src/lib/colorizer.js
+++ b/src/lib/colorizer.js
@@ -1,6 +1,6 @@
 var chalk = require('chalk');
 
-var colors = {
+var defaultColors = {
   BRACE: chalk.gray,
   BRACKET: chalk.gray,
   COLON: chalk.gray,
@@ -8,15 +8,18 @@ var colors = {
   STRING_KEY: chalk.magenta,
   STRING_LITERAL: chalk.yellow,
   NUMBER_LITERAL: chalk.green,
-  BOOLEAN_LITERAL: chalk.cyan
+  BOOLEAN_LITERAL: chalk.cyan,
+  NULL_LITERAL: chalk.white
 };
 
-exports.colorize = function colorize(tokens) {
+exports.colorize = function colorize(tokens, options) {
+  var opts = options || {};
+  var colors = opts.colors || {};
   var str = '';
   var colorFn;
 
   tokens.forEach(function (token) {
-    colorFn = colors[token.type];
+    colorFn = colors[token.type] || defaultColors[token.type];
     str += colorFn ? colorFn(token.value) : token.value;
   });
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,6 +1,6 @@
 const lexer = require('./lexer');
 const colorizer = require('./colorizer');
 
-module.exports = function colorizeJson(json) {
-  return colorizer.colorize(lexer.getTokens(json));
+module.exports = function colorizeJson(json, options) {
+  return colorizer.colorize(lexer.getTokens(json), options);
 };

--- a/src/lib/lexer.js
+++ b/src/lib/lexer.js
@@ -8,7 +8,7 @@ const tokenTypes = [
   { regex: /^"(?:\\.|[^"])*"(?=\s*:)/, tokenType: 'STRING_KEY'},
   { regex: /^"(?:\\.|[^"])*"/, tokenType: 'STRING_LITERAL'},
   { regex: /^true|false/, tokenType: 'BOOLEAN_LITERAL' },
-  { regex: /^null/, tokenType: 'NULL' }
+  { regex: /^null/, tokenType: 'NULL_LITERAL' }
 ];
 
 exports.getTokens = function getTokens(json) {

--- a/src/test/colorizer-test.js
+++ b/src/test/colorizer-test.js
@@ -1,0 +1,72 @@
+var chai = require('chai');
+var chalk = require('chalk');
+var expect = chai.expect;
+
+var lexer = require('../lib/lexer');
+var colorizer = require('../lib/colorizer');
+var customColors = {
+  BRACE: chalk.white,
+  BRACKET: chalk.white,
+  COLON: chalk.white,
+  COMMA: chalk.white,
+  STRING_KEY: chalk.yellow,
+  NULL_LITERAL: chalk.red,
+  STRING_LITERAL: chalk.green,
+  NUMBER_LITERAL: chalk.magenta.bold,
+  BOOLEAN_LITERAL: chalk.cyan
+};
+
+var fixture = {
+  foo: null,
+  bar: {baz: true},
+  number: 13,
+  array: ['values']
+};
+
+
+describe('Colorizer', function () {
+  it('colorizes with default options', function () {
+    var tokens = lexer.getTokens(fixture);
+    var result = colorizer.colorize(tokens);
+
+    expect(result).to.equal([
+      '',
+      '[90m{', '[39m', '[35m\"foo\"', '[39m', '[90m:', '[39m', '[37mnull',
+      '[39m', '[90m,', '[39m', '[35m\"bar\"', '[39m', '[90m:', '[39m', '[90m{',
+      '[39m', '[35m\"baz\"', '[39m', '[90m:', '[39m', '[36mtrue', '[39m', '[90m}',
+      '[39m', '[90m,', '[39m', '[35m\"number\"', '[39m', '[90m:', '[39m', '[32m13',
+      '[39m', '[90m,', '[39m', '[35m\"array\"', '[39m', '[90m:', '[39m', '[90m[',
+      '[39m', '[33m\"values\"', '[39m', '[90m]', '[39m', '[90m}', '[39m'
+    ].join('\u001b'));
+  });
+
+  it('colorizes with custom colors', function () {
+    var tokens = lexer.getTokens(fixture);
+    var result = colorizer.colorize(tokens, {colors: customColors});
+
+    expect(result).to.equal([
+      '',
+      '[37m{', '[39m', '[33m\"foo\"', '[39m', '[37m:', '[39m', '[31mnull',
+      '[39m', '[37m,', '[39m', '[33m\"bar\"', '[39m', '[37m:', '[39m', '[37m{',
+      '[39m', '[33m\"baz\"', '[39m', '[37m:', '[39m', '[36mtrue', '[39m', '[37m}',
+      '[39m', '[37m,', '[39m', '[33m\"number\"', '[39m', '[37m:', '[39m', '[35m', '[1m13',
+      '[22m', '[39m', '[37m,', '[39m', '[33m\"array\"', '[39m', '[37m:', '[39m', '[37m[',
+      '[39m', '[32m\"values\"', '[39m', '[37m]', '[39m', '[37m}', '[39m',
+    ].join('\u001b'));
+  });
+
+  it('colorizes with only specific overrides for colors', function () {
+    var tokens = lexer.getTokens(fixture);
+    var result = colorizer.colorize(tokens, {colors: {NUMBER_LITERAL: chalk.red}});
+
+    expect(result).to.equal([
+      '',
+      '[90m{', '[39m', '[35m\"foo\"', '[39m', '[90m:', '[39m', '[37mnull',
+      '[39m', '[90m,', '[39m', '[35m\"bar\"', '[39m', '[90m:', '[39m', '[90m{',
+      '[39m', '[35m\"baz\"', '[39m', '[90m:', '[39m', '[36mtrue', '[39m', '[90m}',
+      '[39m', '[90m,', '[39m', '[35m\"number\"', '[39m', '[90m:', '[39m', '[31m13',
+      '[39m', '[90m,', '[39m', '[35m\"array\"', '[39m', '[90m:', '[39m', '[90m[',
+      '[39m', '[33m\"values\"', '[39m', '[90m]', '[39m', '[90m}', '[39m'
+    ].join('\u001b'));
+  });
+});

--- a/src/test/lexer-test.js
+++ b/src/test/lexer-test.js
@@ -80,7 +80,7 @@ describe('Lexer', function () {
 
   it('tokenizes null', function () {
     var result = lexer.getTokens('null');
-    expect(result).to.deep.equal([{ type: 'NULL', value: 'null' }]);
+    expect(result).to.deep.equal([{ type: 'NULL_LITERAL', value: 'null' }]);
   });
 
   it('tokenizes a string literal with brace characters', function () {


### PR DESCRIPTION
This PR adds support for specifying custom colors.

I also took the liberty of adding some tests for the colorizing, as well as renamed the `NULL` token to `NULL_LITERAL` (feel free to change this if you feel it is wrong).
