### PR TITLE
Add some semicolons to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you pass a string to the colorize function, it will treat it as pre-serialize
 
 ```js
 var colorize = require('json-colorizer');
-var json = JSON.stringify({"foo": "bar"}, null, 2)
+var json = JSON.stringify({"foo": "bar"}, null, 2);
 console.log(colorize(json);
 ```
 
@@ -30,7 +30,7 @@ You can specify a function to use for coloring individual tokens by providing a 
 
 ```js
 var colorize = require('json-colorizer');
-var chalk = require('chalk')
+var chalk = require('chalk');
 console.log(colorize({ "foo": "bar" }, {
   colors: {
     STRING_KEY: chalk.green


### PR DESCRIPTION
When I sent my "specify colors" PR, I updated the readme, but forgot to follow the coding style in terms on semicolons. This makes it look slightly unprofessional. Sorry about that.

Don't think this warrants a new release necessarily, but it makes the project look nicer on Github :-)