### PR TITLE
Publish only required files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.2.0",
   "description": "A library to format JSON with colors for display in the console",
   "main": "src/lib/index.js",
+  "files": [
+    "src/lib"
+  ],
   "scripts": {
     "test": "mocha src/test",
     "test:watch": "mocha -w src/test",


### PR DESCRIPTION
Hi,

Currently, the published package contains all the project files. Here is the output of `npm pack json-colorizer`

```
npm notice
npm notice 📦  json-colorizer@2.2.0
npm notice === Tarball Contents ===
npm notice 1.1kB  package.json
npm notice 236B   .eslintrc.js
npm notice 47B    .prettierrc
npm notice 64B    .travis.yml
npm notice 174B   example.js
npm notice 1.1kB  LICENSE
npm notice 1.9kB  README.md
npm notice 18.6kB screenshot.png
npm notice 686B   src/lib/colorizer.js
npm notice 206B   src/lib/index.js
npm notice 1.3kB  src/lib/lexer.js
npm notice 3.8kB  src/test/colorizer-test.js
npm notice 3.2kB  src/test/lexer-test.js
npm notice === Tarball Details ===
npm notice name:          json-colorizer
npm notice version:       2.2.0
npm notice filename:      json-colorizer-2.2.0.tgz
npm notice package size:  23.3 kB
npm notice unpacked size: 32.4 kB
npm notice shasum:        fc0767c14c5c8ab6c84bc43327306e2993d94225
npm notice integrity:     sha512-LEHcsdmmIrlF0[...]hJE6enWVjl7bA==
npm notice total files:   13
npm notice
```

To reduce the published package size and to include only the required files I've added the `files` field to `package.json`.  Here is the output `npm pack`:

```
npm notice
npm notice 📦  json-colorizer@2.2.0
npm notice === Tarball Contents ===
npm notice 1.2kB package.json
npm notice 1.1kB LICENSE
npm notice 1.9kB README.md
npm notice 686B  src/lib/colorizer.js
npm notice 206B  src/lib/index.js
npm notice 1.3kB src/lib/lexer.js
npm notice === Tarball Details ===
npm notice name:          json-colorizer
npm notice version:       2.2.0
npm notice filename:      json-colorizer-2.2.0.tgz
npm notice package size:  2.9 kB
npm notice unpacked size: 6.3 kB
npm notice shasum:        90c6c6d7e37e7c1f37654b69f0c395a5fcde1c01
npm notice integrity:     sha512-hh3r6ElOnY4cM[...]KKE07w+Tk+eAg==
npm notice total files:   6
npm notice
json-colorizer-2.2.0
```
