### PR TITLE
Add custom tab-size feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ const json = '{"foo": "bar"}';
 console.log(colorize(json, { pretty: true }));
 ```
 
+When you pass `pretty: true`, tab-size will automatically set to 2. but if you want to specify another tab-size, specify this tab-size instead of `true`.
+
+```js
+const colorize = require('json-colorizer');
+const json = '{"foo": "bar"}';
+console.log(colorize(json, { pretty: 4 }));
+```
+
 ## Specifying colors
 
 __NOTE__: Prior to version 2.x, the colors were specified by referencing `chalk` color functions directly. This required requiring `chalk` into the file. Starting with version 2.x, the colors are specified as a string which is the name (or property path) to the desired color function.

--- a/example.js
+++ b/example.js
@@ -5,5 +5,5 @@ console.log(colorize(pkg, {
   colors: {
     STRING_LITERAL: '#FF0000'
   },
-  pretty: true
+  pretty: 2 // pretty: true
 }));

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -10,7 +10,7 @@ type Token =
   | 'NULL_LITERAL';
 
 interface Options {
-  readonly pretty?: boolean;
+  readonly pretty?: number | boolean;
   readonly colors?: { readonly [token in Token]?: string };
 }
 

--- a/src/lib/lexer.js
+++ b/src/lib/lexer.js
@@ -16,7 +16,7 @@ exports.getTokens = function getTokens(json, options = {}) {
 
   if (options.pretty) {
     const inputObj = typeof json === 'string' ? JSON.parse(json) : json;
-    input = JSON.stringify(inputObj, null, 2);
+    input = JSON.stringify(inputObj, null, typeof options.pretty === 'boolean' ? 2 : options.pretty);
   } else {
     input = typeof json === 'string' ? json : JSON.stringify(json);
   }


### PR DESCRIPTION
Not a big change, but a nice addition. It allows us to determine what we want instead of using 2 indents in the `pretty` option.

If we type `pretty: true`, indent will be 2, but if we type `pretty: 4`, indent will be 4