### PR TITLE
use correct type for colorizeJson()

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -14,6 +14,9 @@ interface Options {
   readonly colors?: { readonly [token in Token]?: string };
 }
 
-declare function colorizeJson(json: string, options?: Options): string;
+declare function colorizeJson(
+  json: string | unknown,
+  options?: Options,
+): string;
 
 export = colorizeJson;


### PR DESCRIPTION
uses "unknown" instead of "any" for the non-string case to show that we
won't be poking into the contents, just serializing them

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.3)_